### PR TITLE
Support python3

### DIFF
--- a/pyrasite/__init__.py
+++ b/pyrasite/__init__.py
@@ -1,7 +1,7 @@
-from inject import CodeInjector
-from inspect import ObjectInspector
-from ipc import PyrasiteIPC
-from reverse import ReverseConnection, ReversePythonConnection
+from .inject import CodeInjector
+from .inspect import ObjectInspector
+from .ipc import PyrasiteIPC
+from .reverse import ReverseConnection, ReversePythonConnection
 
 __version__ = '2.0beta'
 __all__ = ('CodeInjector', 'ObjectInspector', 'PyrasiteIPC',

--- a/pyrasite/inject.py
+++ b/pyrasite/inject.py
@@ -31,7 +31,7 @@ Authors:
 import os
 import warnings
 
-from utils import run
+from .utils import run
 
 
 class CodeInjector(object):

--- a/pyrasite/inject.py
+++ b/pyrasite/inject.py
@@ -56,7 +56,7 @@ class CodeInjector(object):
             # Allow payloads to import modules alongside them
             'PyRun_SimpleString("import sys; sys.path.insert(0, \\"%s\\");")' %
                 os.path.dirname(self.filename),
-            'PyRun_SimpleString("execfile(\\"%s\\")")' % self.filename,
+            'PyRun_SimpleString("exec(open(\\"%s\\").read())")' % self.filename,
             'PyGILState_Release($1)',
             ]
         run('%sgdb -p %d -batch %s' % (self.gdb_prefix, self.pid,

--- a/pyrasite/inspect.py
+++ b/pyrasite/inspect.py
@@ -15,7 +15,7 @@
 #
 # Copyright (C) 2011 Red Hat, Inc.
 
-from utils import run
+from .utils import run
 
 
 class ObjectInspector(object):

--- a/pyrasite/ipc.py
+++ b/pyrasite/ipc.py
@@ -139,7 +139,8 @@ class PyrasiteIPC(object):
 
     def send(self, data):
         """Send arbitrary data to the process via self.sock"""
-        header = ''
+        header = b''
+        data = data.encode('utf-8')
         if self.reliable:
             header = struct.pack('<L', len(data))
         self.sock.sendall(header + data)
@@ -150,7 +151,7 @@ class PyrasiteIPC(object):
             header_data = self.recv_bytes(4)
             if len(header_data) == 4:
                 msg_len = struct.unpack('<L', header_data)[0]
-                data = self.recv_bytes(msg_len)
+                data = self.recv_bytes(msg_len).decode('utf-8')
                 if len(data) == msg_len:
                     return data
         else:
@@ -158,10 +159,10 @@ class PyrasiteIPC(object):
 
     def recv_bytes(self, n):
         """Receive n bytes from a socket"""
-        data = ''
+        data = b''
         while len(data) < n:
             chunk = self.sock.recv(n - len(data))
-            if chunk == '':
+            if not chunk:
                 break
             data += chunk
         return data

--- a/pyrasite/payloads/dump_stacks.py
+++ b/pyrasite/payloads/dump_stacks.py
@@ -1,6 +1,6 @@
 import sys, traceback
 
-for thread, frame in sys._current_frames().iteritems():
+for thread, frame in sys._current_frames().items():
     print('Thread 0x%x' % thread)
     traceback.print_stack(frame)
     print

--- a/pyrasite/reverse.py
+++ b/pyrasite/reverse.py
@@ -74,7 +74,7 @@ class ReverseConnection(threading.Thread, PyrasiteIPC):
                         running = False
                     else:
                         running = self.on_command(cmd)
-            except Exception, e:
+            except Exception as e:
                 print(str(e))
                 running = False
             if not running:
@@ -94,7 +94,7 @@ class ReversePythonConnection(ReverseConnection):
         try:
             exec(cmd)
             output = buffer.getvalue()
-        except Exception, e:
+        except Exception as e:
             output = str(e)
         finally:
             sys.stdout = sys.__stdout__

--- a/pyrasite/reverse.py
+++ b/pyrasite/reverse.py
@@ -23,7 +23,10 @@ import sys
 import socket
 import threading
 
-from StringIO import StringIO
+if sys.version_info[0] == 3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 from pyrasite.ipc import PyrasiteIPC
 
 

--- a/pyrasite/utils.py
+++ b/pyrasite/utils.py
@@ -6,11 +6,11 @@ from __future__ import division
 def humanize_bytes(bytes, precision=1):
     """Return a humanized string representation of a number of bytes."""
     abbrevs = (
-        (1 << 50L, 'PB'),
-        (1 << 40L, 'TB'),
-        (1 << 30L, 'GB'),
-        (1 << 20L, 'MB'),
-        (1 << 10L, 'kB'),
+        (1 << 50, 'PB'),
+        (1 << 40, 'TB'),
+        (1 << 30, 'GB'),
+        (1 << 20, 'MB'),
+        (1 << 10, 'kB'),
         (1, 'bytes')
     )
     if bytes == 1:


### PR DESCRIPTION
First step: support injecting code into python3 apps from pyrasite running in python2.

Second step: get the pyrasite-gui working under python3 (this is 99% of the way there, but the Stacks tab is only shows the error "string expected, got 'str'". Feels like a pygobject3 bug)
