### PR TITLE
Allow pyrasite to run on python3

### DIFF
--- a/pyrasite/ipc.py
+++ b/pyrasite/ipc.py
@@ -100,7 +100,7 @@ class PyrasiteIPC(object):
         (fd, filename) = tempfile.mkstemp()
         tmp = os.fdopen(fd, 'w')
         path = dirname(abspath(join(pyrasite.__file__, '..')))
-        payload = file(join(path, 'pyrasite', 'reverse.py'))
+        payload = open(join(path, 'pyrasite', 'reverse.py'))
         tmp.write('import sys; sys.path.insert(0, "%s")\n' % path)
 
         for line in payload.readlines():

--- a/pyrasite/payloads/dump_stacks.py
+++ b/pyrasite/payloads/dump_stacks.py
@@ -1,6 +1,7 @@
+from __future__ import print_function
 import sys, traceback
 
 for thread, frame in sys._current_frames().items():
     print('Thread 0x%x' % thread)
     traceback.print_stack(frame)
-    print
+    print()

--- a/pyrasite/tools/gui.py
+++ b/pyrasite/tools/gui.py
@@ -82,7 +82,8 @@ class Process(pyrasite.PyrasiteIPC, GObject.GObject):
     @property
     def title(self):
         if not getattr(self, '_title', None):
-            self._title = run('ps --no-heading -o cmd= -p %d' % self.pid)[1]
+            self._title = run('ps --no-heading -o cmd= -p %d' % self.pid)[1] \
+                    .decode('utf-8')
         return self._title
 
 

--- a/pyrasite/tools/gui.py
+++ b/pyrasite/tools/gui.py
@@ -86,11 +86,11 @@ class Process(pyrasite.PyrasiteIPC, GObject.GObject):
         return self._title
 
 
-class ProcessTreeStore(Gtk.TreeStore):
+class ProcessListStore(Gtk.ListStore):
     """This TreeStore finds all running python processes."""
 
     def __init__(self, *args):
-        Gtk.TreeStore.__init__(self, str, Process, Pango.Style)
+        Gtk.ListStore.__init__(self, str, Process, Pango.Style)
         for pid in os.listdir('/proc'):
             try:
                 pid = int(pid)
@@ -98,8 +98,8 @@ class ProcessTreeStore(Gtk.TreeStore):
                 try:
                     maps = open('/proc/%d/maps' % pid).read().strip()
                     if 'python' in maps:
-                        self.append(None, (proc.title.strip(), proc,
-                                           Pango.Style.NORMAL))
+                        self.append((proc.title.strip(), proc,
+                                     Pango.Style.NORMAL))
                 except IOError:
                     pass
             except ValueError:
@@ -670,7 +670,7 @@ class PyrasiteWindow(Gtk.Window):
             store.set_value(iter, 2, Pango.Style.NORMAL)
 
     def create_tree(self):
-        tree_store = ProcessTreeStore()
+        tree_store = ProcessListStore()
         tree_view = Gtk.TreeView()
         self.tree_view = tree_view
         tree_view.set_model(tree_store)

--- a/pyrasite/tools/gui.py
+++ b/pyrasite/tools/gui.py
@@ -32,7 +32,10 @@ import threading
 
 from os.path import join, abspath, dirname
 from random import randrange
-from meliae import loader
+try:
+    from meliae import loader
+except:
+    pass
 from gi.repository import GLib, GObject, Pango, Gtk, WebKit
 
 import pyrasite
@@ -606,6 +609,9 @@ class PyrasiteWindow(Gtk.Window):
         try:
             objects = loader.load('/tmp/%d.objects' % proc.pid,
                                   show_prog=False)
+        except NameError:
+            log.debug("Meliae not available, continuing...")
+            return
         except:
             log.debug("Falling back to slower meliae object dump loader")
             objects = loader.load('/tmp/%d.objects' % proc.pid,

--- a/pyrasite/tools/gui.py
+++ b/pyrasite/tools/gui.py
@@ -450,10 +450,10 @@ class PyrasiteWindow(Gtk.Window):
     def inject_js(self):
         log.debug("Injecting jQuery")
         js = join(dirname(abspath(__file__)), 'js')
-        jquery = file(join(js, 'jquery-1.7.1.min.js'))
+        jquery = open(join(js, 'jquery-1.7.1.min.js'))
         self.info_view.execute_script(jquery.read())
         jquery.close()
-        sparkline = file(join(js, 'jquery.sparkline.min.js'))
+        sparkline = open(join(js, 'jquery.sparkline.min.js'))
         self.info_view.execute_script(sparkline.read())
         sparkline.close()
 
@@ -638,7 +638,7 @@ class PyrasiteWindow(Gtk.Window):
         payloads = os.path.join(os.path.abspath(os.path.dirname(
             pyrasite.__file__)), 'payloads')
         dump_stacks = os.path.join(payloads, 'dump_stacks.py')
-        code = proc.cmd(file(dump_stacks).read())
+        code = proc.cmd(open(dump_stacks).read())
         self.update_progress(0.6)
 
         self.source_buffer.set_text('')


### PR DESCRIPTION
This is the other half of Issue #14, letting pyrasite run on Python 3

These two pull requests may limit python 2.6 compatability.  A sprinkling of from **future** import print_function may be neccessay
