### PR TITLE
gobject depenedency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,7 @@ Requirements
 ~~~~~~~~~~~~
 
   - gdb (https://www.gnu.org/s/gdb) (version 7.3+)
+  - python-gobject-dev (on debian or ubuntu: apt-get install python-gobject-dev)
   - Cython (http://cython.org)
   - meliae (https://launchpad.net/meliae) 
     - easy_install/pip may not work for this install. If not, use the tarball from the distribution website

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,12 @@ except ImportError:
     print "We require meliae to be installed."
     exit(1)
 
+try:
+    from gi.repository import  GLib, GObject, Pango, Gtk, WebKit
+except ImportError:
+    print "We require python-gobject-dev installed.  Use: apt-get install python-gobject-dev"
+    exit(1)
+
 setup(name='pyrasite',
       version=version,
       description="Inject code into a running Python process",
@@ -23,7 +29,7 @@ setup(name='pyrasite',
       license='GPLv3',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
-      zip_safe=True,
+      zip_safe=False,
       install_requires=[
         "Cython", # Needed for meliae
         "meliae",


### PR DESCRIPTION
- docs for python-gobject-dev requirement
- setup.py test for importing gobject modules
