### PR TITLE
Stop printing '()' instead of blank lines when using Python 2

### DIFF
--- a/pyrasite/payloads/dump_stacks.py
+++ b/pyrasite/payloads/dump_stacks.py
@@ -3,4 +3,4 @@ import sys, traceback
 for thread, frame in sys._current_frames().items():
     print('Thread 0x%x' % thread)
     traceback.print_stack(frame)
-    print()
+    print('')

--- a/pyrasite/tools/shell.py
+++ b/pyrasite/tools/shell.py
@@ -39,4 +39,4 @@ def shell():
         pass
 
     ipc.close()
-    print()
+    print('')


### PR DESCRIPTION
You can see this, e.g., in the Stacks tab of pyrasite-gui
