### PR TITLE
Add support for tox (http://tox.testrun.org/) and Travis CI (http://travis-ci.org/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 dist
 docs/_build
 __pycache__
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+
+python:
+  - 2.6
+  - 2.7
+
+install: python setup.py install
+
+script:
+  - pip install --use-mirrors unittest2
+  - sudo apt-get install gdb
+  - sudo unit2 discover

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27
+
+[testenv]
+commands = sudo {envbindir}/unit2 discover
+deps = unittest2


### PR DESCRIPTION
Successful Travis CI run: http://travis-ci.org/#!/msabramo/pyrasite/jobs/1690081

To set up Travis CI for your own repo, see http://about.travis-ci.org/docs/user/getting-started/

Output of tox:

```
marca@ubuntu:~/dev/git-repos/pyrasite$ sudo tox 2>&1 | tee tox.out
...
___________________________________ summary ____________________________________
  py26: commands succeeded
  py27: commands succeeded
  congratulations :)
```
