### PR TITLE
Add the ability to control the IPC timeout.

### DIFF
--- a/pyrasite/ipc.py
+++ b/pyrasite/ipc.py
@@ -64,7 +64,7 @@ class PyrasiteIPC(object):
     # shell payloads with netcat.
     reliable = True
 
-    def __init__(self, pid, reverse='ReversePythonConnection'):
+    def __init__(self, pid, reverse='ReversePythonConnection', timeout=5):
         super(PyrasiteIPC, self).__init__()
         self.pid = pid
         self.sock = None
@@ -72,6 +72,7 @@ class PyrasiteIPC(object):
         self.hostname = None
         self.port = None
         self.reverse = reverse
+        self.timeout = float(timeout)
 
     def __enter__(self):
         self.connect()
@@ -165,7 +166,7 @@ class PyrasiteIPC(object):
         """Wait for the injected payload to connect back to us"""
         (clientsocket, address) = self.server_sock.accept()
         self.sock = clientsocket
-        self.sock.settimeout(5)
+        self.sock.settimeout(self.timeout)
         self.address = address
 
     def cmd(self, cmd):

--- a/pyrasite/main.py
+++ b/pyrasite/main.py
@@ -92,6 +92,10 @@ def main():
                         help="Set where output is to be printed. 'procstreams'" 
                              " prints output in stdout/stderr of running process"
                              " and 'localterm' prints output in local terminal.")
+    parser.add_argument('--ipc-timeout', dest='ipc_timeout', default=5,
+                        action='store', type=int,
+                        help="The number of seconds to wait for the injected"
+                             " code to reply over IPC before giving up.")
 
     if len(sys.argv) == 1:
         parser.print_help()
@@ -129,7 +133,8 @@ def main():
     
     if args.output_type == 'localterm':
         # Create new IPC connection to the process.
-        ipc = pyrasite.PyrasiteIPC(pid, 'ReversePythonConnection')
+        ipc = pyrasite.PyrasiteIPC(pid, 'ReversePythonConnection',
+                                   timeout=ipc_timeout)
         ipc.connect()
         print("Pyrasite Shell %s" % pyrasite.__version__)
         print("Connected to '%s'" % ipc.title)

--- a/pyrasite/tools/shell.py
+++ b/pyrasite/tools/shell.py
@@ -15,6 +15,7 @@
 #
 # Copyright (C) 2011-2013 Red Hat, Inc., Luke Macken <lmacken@redhat.com>
 
+import os
 import sys
 import pyrasite
 
@@ -32,7 +33,8 @@ def shell():
         print(usage)
         sys.exit(1)
 
-    ipc = pyrasite.PyrasiteIPC(pid, 'ReversePythonShell')
+    ipc = pyrasite.PyrasiteIPC(pid, 'ReversePythonShell',
+                               timeout=os.getenv('PYRASITE_IPC_TIMEOUT') or 5)
     ipc.connect()
 
     print("Pyrasite Shell %s" % pyrasite.__version__)


### PR DESCRIPTION
With a hardcoded 5-second timeout, it's impossible to run commands with pyrasite-shell that take more than 5 seconds. I was bitten by this recently when trying to get heap dumps from a large process, but it can be reproduced easily with time.sleep:

``` console
$ pyrasite-shell 11166
Pyrasite Shell 2.0
Connected to 'python'
Python 2.7.6 (default, Jun 22 2015, 17:58:13) 
[GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
(DistantInteractiveConsole)

>>> import time
>>> time.sleep(10)

Traceback (most recent call last):
  File "/home/jakeschmidt/pyrasite/env/bin/pyrasite-shell", line 9, in <module>
    load_entry_point('pyrasite==2.0', 'console_scripts', 'pyrasite-shell')()
  File "/home/jakeschmidt/pyrasite/env/local/lib/python2.7/site-packages/pyrasite-2.0-py2.7.egg/pyrasite/tools/shell.py", line 70, in shell
    payload = ipc.recv()
  File "/home/jakeschmidt/pyrasite/env/local/lib/python2.7/site-packages/pyrasite-2.0-py2.7.egg/pyrasite/ipc.py", line 190, in recv
    header_data = self.recv_bytes(4)
  File "/home/jakeschmidt/pyrasite/env/local/lib/python2.7/site-packages/pyrasite-2.0-py2.7.egg/pyrasite/ipc.py", line 203, in recv_bytes
    chunk = self.sock.recv(n - len(data))
socket.timeout: timed out
```
