### PR TITLE
[MacOSX support] pyrasite uses lldb on macosx

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,11 @@ Requirements
 
  * `gdb <https://www.gnu.org/s/gdb>`_ (version 7.3+ (or RHEL5+))
  
-On OS X you will need to have a codesigned gdb - see https://sourceware.org/gdb/wiki/BuildingOnDarwin
+On OS X:
+
+ * `xcode command line tools - lldb <https://developer.apple.com/download/more/>`_ (version 7+)
+
+Or you will need to have a codesigned gdb - see https://sourceware.org/gdb/wiki/BuildingOnDarwin
 if you get errors while running with --verbose which mention codesigning.
 
 Compatiblity


### PR DESCRIPTION
- require xcode command line tools - lldb
- use lldb on macosx to inject code
- tested lldb version: lldb-340.4.119
