### PR TITLE
Fix travis - Remove dropped pip argument, update python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: python
 
 python:
-  - 2.6
   - 2.7
-  - 3.2
-  - 3.3
   - 3.4
+  - 3.5
+  - 3.6
+  - 3.7
 
 install:
   - sudo apt-get install -qq gdb python-all-dbg
   - python setup.py install
-  - if [[ $TRAVIS_PYTHON_VERSION != '2.5' ]]; then pip install coveralls --use-mirrors && export HAS_COVERALLS=1; fi
+  - pip install coveralls && export HAS_COVERALLS=1
 
 script:
   - nosetests -v --with-coverage --cover-erase --cover-package=pyrasite --exclude=test_injecting_into_all_interpreters

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py35, py36
+envlist = py27, py34, py35, py36, py37
 
 [testenv]
 commands = nosetests


### PR DESCRIPTION
Align tox / travis updated on currently-supported versions of python from https://devguide.python.org/#branchstatus