### PR TITLE
docs: fix simple typo, outpu -> output

### DIFF
--- a/pyrasite/tools/memory_viewer.py
+++ b/pyrasite/tools/memory_viewer.py
@@ -96,7 +96,7 @@ class PyrasiteMemoryViewer(object):
         bt = urwid.Padding(self.bigtext, 'left', None)
         bt = urwid.AttrWrap(bt, 'bigtext')
 
-        # Create the object outpu
+        # Create the object output
         self.object_output = urwid.Text("", wrap='any')
         ca = urwid.AttrWrap(self.object_output, 'object_output')
 


### PR DESCRIPTION
There is a small typo in pyrasite/tools/memory_viewer.py.

Should read `output` rather than `outpu`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md